### PR TITLE
Adjust DaoMutation and migration for NULL MUTATION_STATUS

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -52,11 +52,11 @@ public final class DaoMutation {
         if (!MySQLbulkLoader.isBulkLoad()) {
             throw new DaoException("You have to turn on MySQLbulkLoader in order to insert mutations");
         } else {
-        	int result = 1;
-        	if (newMutationEvent) {
-        		//add event first, as mutation has a Foreign key constraint to the event:
-        		result = addMutationEvent(mutation.getEvent())+1;
-            } 
+            int result = 1;
+            if (newMutationEvent) {
+                //add event first, as mutation has a Foreign key constraint to the event:
+                result = addMutationEvent(mutation.getEvent())+1;
+            }
             MySQLbulkLoader.getMySQLbulkLoader("mutation").insertRecord(
                     Long.toString(mutation.getMutationEventId()),
                     Integer.toString(mutation.getGeneticProfileId()),
@@ -143,13 +143,13 @@ public final class DaoMutation {
                     "SELECT sample_profile.`SAMPLE_ID`, COUNT(DISTINCT mutation_event.`CHR`, mutation_event.`START_POSITION`, " +
                     "mutation_event.`END_POSITION`, mutation_event.`REFERENCE_ALLELE`, mutation_event.`TUMOR_SEQ_ALLELE`) AS MUTATION_COUNT " +
                     "FROM `sample_profile` " +
-                    "LEFT JOIN mutation ON mutation.`SAMPLE_ID` = sample_profile.`SAMPLE_ID`" +
-                    "LEFT JOIN mutation_event ON mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID`" +
-                    "INNER JOIN genetic_profile ON genetic_profile.`GENETIC_PROFILE_ID` = sample_profile.`GENETIC_PROFILE_ID`" +
-                    "WHERE mutation.`MUTATION_STATUS` <> 'GERMLINE' " +
-                    "AND mutation_event.`MUTATION_TYPE` <> 'Fusion' " +
+                    "LEFT JOIN mutation ON mutation.`SAMPLE_ID` = sample_profile.`SAMPLE_ID` " +
+                    "LEFT JOIN mutation_event ON mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
+                    "INNER JOIN genetic_profile ON genetic_profile.`GENETIC_PROFILE_ID` = sample_profile.`GENETIC_PROFILE_ID` " +
+                    "WHERE genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
+                    "AND ( mutation.`MUTATION_STATUS` <> 'GERMLINE' OR mutation.`MUTATION_STATUS` IS NULL ) " +
+                    "AND ( mutation_event.`MUTATION_TYPE` <> 'Fusion' OR mutation_event.`MUTATION_TYPE` IS NULL ) " +
                     "AND genetic_profile.`GENETIC_PROFILE_ID`=? " +
-                    "AND genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
                     "GROUP BY sample_profile.`GENETIC_PROFILE_ID` , sample_profile.`SAMPLE_ID`;");
             pstmt.setInt(1, geneticProfile.getGeneticProfileId());
             Map<Integer, String> mutationCounts = new HashMap<Integer, String>();
@@ -164,7 +164,7 @@ public final class DaoMutation {
                     false, "30", geneticProfile.getCancerStudyId());
                 DaoClinicalAttributeMeta.addDatum(attr);
             }
-            
+
             for (Map.Entry<Integer, String> mutationCount : mutationCounts.entrySet()) {
                 DaoClinicalData.addSampleDatum(mutationCount.getKey(), MUTATION_COUNT_ATTR_ID, mutationCount.getValue());
             }
@@ -174,7 +174,7 @@ public final class DaoMutation {
             JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
         }
     }
-    
+
     public static int calculateMutationCountByKeyword(int profileId) throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;
@@ -995,7 +995,7 @@ public final class DaoMutation {
      * @param profileId
      * @return Map &lt; event id, sampleCount &gt;
      * @throws DaoException
-     * 
+     *
      * @deprecated  We believe that this method is no longer called by any part of the codebase, and it will soon be deleted.
      */
     @Deprecated
@@ -1454,7 +1454,7 @@ public final class DaoMutation {
             JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
         }
     }
-    
+
     /**
      * Gets all tiers in alphabetical order.
      *
@@ -1463,17 +1463,17 @@ public final class DaoMutation {
      * @throws DaoException Database Error.
      */
     public static List<String> getTiers(String _cancerStudyStableIds) throws DaoException {
-	String[] cancerStudyStableIds = _cancerStudyStableIds.split(",");
+        String[] cancerStudyStableIds = _cancerStudyStableIds.split(",");
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         List<String> tiers = new ArrayList<String>();
         ArrayList<GeneticProfile> geneticProfiles = new ArrayList<>();
-	for (String cancerStudyStableId: cancerStudyStableIds) {
-		geneticProfiles.addAll(DaoGeneticProfile.getAllGeneticProfiles(
-			DaoCancerStudy.getCancerStudyByStableId(cancerStudyStableId).getInternalId()
-		));
-	}
+        for (String cancerStudyStableId: cancerStudyStableIds) {
+            geneticProfiles.addAll(DaoGeneticProfile.getAllGeneticProfiles(
+                DaoCancerStudy.getCancerStudyByStableId(cancerStudyStableId).getInternalId()
+            ));
+        }
         for (GeneticProfile geneticProfile : geneticProfiles) {
             if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.MUTATION_EXTENDED)) {
                 try {
@@ -1494,10 +1494,10 @@ public final class DaoMutation {
                 }
             }
         }
-        
+
         return tiers;
     }
-    
+
     /**
      * Returns the number of tiers in the cancer study..
      *
@@ -1509,7 +1509,7 @@ public final class DaoMutation {
         List<String> tiers = getTiers(_cancerStudyStableIds);
         return tiers.size();
     }
-    
+
     /**
      * Returns true if there are "Putative_Driver" or "Putative_Passenger" values in the
      * binary annotation column. Otherwise, it returns false.
@@ -1519,17 +1519,17 @@ public final class DaoMutation {
      * @throws DaoException Database Error.
      */
     public static boolean hasDriverAnnotations(String _cancerStudyStableIds) throws DaoException {
-	String[] cancerStudyStableIds = _cancerStudyStableIds.split(",");
-	Connection con = null;
+        String[] cancerStudyStableIds = _cancerStudyStableIds.split(",");
+        Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         List<String> driverValues = new ArrayList<String>();
         ArrayList<GeneticProfile> geneticProfiles = new ArrayList<>();
-	for (String cancerStudyStableId: cancerStudyStableIds) {
-		geneticProfiles.addAll(
-			DaoGeneticProfile.getAllGeneticProfiles(DaoCancerStudy.getCancerStudyByStableId(cancerStudyStableId).getInternalId())
-		);
-	}
+        for (String cancerStudyStableId: cancerStudyStableIds) {
+            geneticProfiles.addAll(
+                DaoGeneticProfile.getAllGeneticProfiles(DaoCancerStudy.getCancerStudyByStableId(cancerStudyStableId).getInternalId())
+            );
+        }
         for (GeneticProfile geneticProfile : geneticProfiles) {
             if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.MUTATION_EXTENDED)) {
                 try {

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -510,8 +510,8 @@ LEFT JOIN mutation ON mutation.`SAMPLE_ID` = sample_profile.`SAMPLE_ID`
 LEFT JOIN mutation_event ON mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID`
 INNER JOIN genetic_profile ON genetic_profile.`GENETIC_PROFILE_ID` = sample_profile.`GENETIC_PROFILE_ID`
 WHERE genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED'
-AND mutation.`MUTATION_STATUS` <> 'GERMLINE' 
-AND mutation_event.`MUTATION_TYPE` <> 'Fusion'
+AND ( mutation.`MUTATION_STATUS` <> 'GERMLINE' OR mutation.`MUTATION_STATUS` IS NULL )
+AND ( mutation_event.`MUTATION_TYPE` <> 'Fusion' OR mutation_event.`MUTATION_TYPE` IS NULL )
 GROUP BY sample_profile.`GENETIC_PROFILE_ID` , sample_profile.`SAMPLE_ID`;
 
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.7.1";


### PR DESCRIPTION
- also some whitespace cleanup in DaoMutation

When MUTATION_STATUS field contained a null value, the record was discarded as if it were GERMLINE.

The same logic was applied to the MUTATION_TYPE field, which could possibly be null (even though none of our studies contained a null in this field)